### PR TITLE
Re-add authentication to the prototype 

### DIFF
--- a/app/config.json
+++ b/app/config.json
@@ -1,4 +1,3 @@
 {
-  "serviceName": "Service name goes here",
-  "useAuth": "false"
+  "serviceName": "Service name goes here"
 }


### PR DESCRIPTION
* Remove authentication line in config.json to reactivate the authentication on the prototype.
* To take effect, it requires the vars to be set in Heroku - which are already there, so this automatically will re-enable password authentication to access the prototype.